### PR TITLE
Fix compilation

### DIFF
--- a/tcplog_dumper.c
+++ b/tcplog_dumper.c
@@ -214,7 +214,7 @@ do_err(int rv, const char *message, ...)
  * Create an IP checksum from a header.
  */
 static void
-add_ip_cksum(struct ip *hdr)
+add_ip_cksum(aligned_ip_hdr *hdr)
 {
 	uint16_t *in;
 	uint32_t sum;
@@ -244,7 +244,7 @@ add_ip_cksum(struct ip *hdr)
  * Create a TCP checksum from a header.
  */
 static void
-add_tcp_cksum(const struct extract_context *ctx, struct tcphdr *th,
+add_tcp_cksum(const struct extract_context *ctx, aligned_tcp_hdr *th,
     uint16_t len)
 {
 	register const uint16_t *in;
@@ -1023,8 +1023,8 @@ pcap_packetblock(struct tcp_log_buffer *buf, struct extract_context *ctx)
 	struct pcapng_epb epb;
 	struct pcapng_blockend epb_end;
 	struct timeval utc_tv;
-	struct ip *iphdr;
-	struct ip6_hdr *ip6hdr;
+	aligned_ip_hdr *iphdr;
+	aligned_ip6_hdr *ip6hdr;
 	struct iovec iov[MAX_IOVS];
 	bitstr_t bit_decl(free_map, MAX_IOVS);
 	uint64_t ts;
@@ -1085,7 +1085,8 @@ pcap_packetblock(struct tcp_log_buffer *buf, struct extract_context *ctx)
 	hdr_len = epb.pktlen - buf->tlb_len;
 
 	/* Add the TCP checksum */
-	add_tcp_cksum(ctx, &buf->tlb_th, tcp_hlen + buf->tlb_len);
+	add_tcp_cksum(ctx, (aligned_tcp_hdr *)&buf->tlb_th,
+	    tcp_hlen + buf->tlb_len);
 
 	/*
 	 * Assign the first IOVs. Overall layout looks like this:

--- a/tcplog_dumper.h
+++ b/tcplog_dumper.h
@@ -36,6 +36,7 @@
 
 typedef struct ip aligned_ip_hdr __aligned(2);
 typedef struct ip6_hdr aligned_ip6_hdr __aligned(2);
+typedef struct tcphdr aligned_tcp_hdr __aligned(2);
 
 struct extract_context;
 


### PR DESCRIPTION
In [9ee759f3676f](https://cgit.FreeBSD.org/src/commit/?id=9ee759f3676f700f8224a95216f659f87f5d9ae9) the alignment of the structures used for the IPv4, IPv6, and TCP header was reduced to 1.
This causes the compilation to fail due to -Wcast-align in combination with -Werror.
This could be worked around by using
CFLAGS += -Wno-error=cast-align
but I prefer to fix it.